### PR TITLE
Make Opus sample entry lowercase

### DIFF
--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -24,7 +24,7 @@ const sampleEntryCodesISO = {
     mlpa: true,
     mp4a: true,
     'raw ': true,
-    Opus: true,
+    opus: true,   // browsers expect this to be lowercase despite MP4RA says 'Opus'
     samr: true,
     sawb: true,
     sawp: true,


### PR DESCRIPTION
This commit violates RFC6381 + MP4RA ISO code list for compatibility with browsers and other players.

Chrome and Firefox accept `opus` codec only as lowercase despite ISO code has a capital O:
```
> MediaSource.isTypeSupported('audio/mp4; codecs="opus"')
true
> MediaSource.isTypeSupported('audio/mp4; codecs="Opus"')
false
```
No player plays an M3U8 with `CODECS="Opus"`, but some players do play an M3U8 with `CODECS="opus"`.
`codecs="opus"` is also playable in DASH.

### This PR will...

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
